### PR TITLE
Fix broken local builds

### DIFF
--- a/image/startup.sh
+++ b/image/startup.sh
@@ -16,8 +16,10 @@
 source ~/.bashrc
 echo "===================================================================="
 if [ ! -d /tmp/uyuni-docs ]; then
-echo " Git repository: ${GITREPO}"
-echo " Git reference: ${GITREF}"
+  echo " Git repository: ${GITREPO}"
+  echo " Git reference: ${GITREF}"
+else
+  echo " Git repository: A folder from outside the container is being used"
 fi
 echo " Product: ${PRODUCT}"
 echo " Make command: ${COMMAND}"

--- a/uyuni-docs-helper
+++ b/uyuni-docs-helper
@@ -47,7 +47,7 @@ print_ok() {
 }
 
 print_incorrect_syntax() {
-  print_error "Incorrect syntax. Use ${SCRIPT} -h for help"
+  print_error "Incorrect syntax: ${1} (use ${SCRIPT} -h for help)"
   exit 1
 }
 
@@ -68,7 +68,7 @@ print_help() {
   echo "                            one source for this to work"
   echo ""
   echo "${SCRIPT} can build documentation from two sources. Different parameters apply for each case."
-  echo "If both a local got repository and a remote git repository are specified, the remote git"
+  echo "If both a local git repository and a remote git repository are specified, the local git"
   echo "repository is used"
   echo ""
   echo "Remote Git repository:"
@@ -100,7 +100,7 @@ print_help() {
 ARGS=$(getopt -o hg:r:l:o:p:c:t:s --long help,gitrepo:,gitref:,localclone:,output:,product:,command:,tag:,serve -n "${SCRIPT}" -- "$@")
 if [ $? -ne 0 ];
 then
-  print_incorrect_syntax
+  print_incorrect_syntax "Invalid getopt call, notify this to the script maintainers"
 fi
 eval set -- "${ARGS}"
 
@@ -117,20 +117,19 @@ while true ; do
     -t|--tag)        IMAGE="${IMAGE}:${2}"; shift 2;;
     -s|--serve)      SERVE=1; PORTS='-p 8000:8000'; shift 1;;
     --)              shift ; break ;;
-    *)               print_incorrect_syntax; exit 1;;
+    *)               print_incorrect_syntax "Invalid arguements in the call"; exit 1;;
   esac
 done
 
 # Command is mandatory
 if [ -z ${COMMAND} ]; then
-  print_incorrect_syntax
+  print_incorrect_syntax "-c is mandatory"
 fi
 
 # Print a special error for the help command
 if [ "${COMMAND}" == "help" ]; then
   if [ -z ${LOCALCLONE} ] && [ -z ${GITREPO} ]; then
-    print_error "A source (a remote or local git repository) is needed for this."
-    print_incorrect_syntax
+    print_incorrect_syntax "A source (a remote or local git repository) is needed for this."
   # Define a default product, if none is available, so we can show the help
   elif [ -z ${PRODUCT} ]; then
     PRODUCT='suma'
@@ -159,7 +158,7 @@ if [ -z ${LOCALCLONE} ]; then
   fi
 else
   if [ ! -z ${OUTPUT} ]; then
-    print_incorrect_syntax
+    print_incorrect_syntax "Using -o together with -l is invalid"
   fi
   if [ ! -d ${LOCALCLONE} ]; then
     print_error "${LOCALCLONE} is not a directory or does not exist"

--- a/uyuni-docs-helper
+++ b/uyuni-docs-helper
@@ -67,7 +67,9 @@ print_help() {
   echo "                            possible commands. Be aware you still need to specify"
   echo "                            one source for this to work"
   echo ""
-  echo "${SCRIPT} can build documentation from two sources. Different parameters apply for each case"
+  echo "${SCRIPT} can build documentation from two sources. Different parameters apply for each case."
+  echo "If both a local got repository and a remote git repository are specified, the remote git"
+  echo "repository is used"
   echo ""
   echo "Remote Git repository:"
   echo "-g|--gitrepo <REPOSITORY> A path to a HTTP git repository where the code for the"
@@ -142,12 +144,6 @@ fi
 
 # Either a remote source or a local one must be used
 if [ -z ${LOCALCLONE} ]; then
-  if [ -z ${GITREPO} ]; then
-    print_incorrect_syntax
-  fi
-  if [ -z ${GITREF} ]; then
-    print_incorrect_syntax
-  fi
   SOURCE="-e GITREPO=${GITREPO} -e GITREF=${GITREF}"
   if [ ! -z ${OUTPUT} ]; then
     if [ ! -d ${OUTPUT} ]; then
@@ -163,9 +159,6 @@ if [ -z ${LOCALCLONE} ]; then
   fi
 else
   if [ ! -z ${OUTPUT} ]; then
-    print_incorrect_syntax
-  fi
-  if [ ! -z ${GITREPO} ] || [ ! -z ${GITREF} ]; then
     print_incorrect_syntax
   fi
   if [ ! -d ${LOCALCLONE} ]; then


### PR DESCRIPTION
We didn't test enough the last PR where we added default for the Git remote repo and ref.

Therefore, both variables are now always defined, and we performed useless checks when using a remote git repository, and wrong checks when using a local repository.

Checks are removed now, and we specify that if the user specifies both remote and local, the local is used.

Also some improvements for the error syntax messages.