### PR TITLE
Solution added for wrong file system error

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -28,7 +28,7 @@ If you see the following error:
 Error: ".local/share/containers/storage/btrfs" is not on a btrfs filesystem: prerequisites for driver not satisfied (wrong filesystem?)
 ```
 
-This issue appeared when using the XFS filesystem for my /home/ directory. By default containers are configured to use the same file system as the root partition. To ensure general compatibility set the container driver to `overlay`. 
+This issue appeared when using the XFS filesystem for my /home/ directory. By default containers are configured to use a supported driver for the file system in use. To ensure general compatibility set the container driver to `overlay`. 
 
  As root modify `/etc/containers/storage.conf`: 
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -28,7 +28,7 @@ If you see the following error:
 Error: ".local/share/containers/storage/btrfs" is not on a btrfs filesystem: prerequisites for driver not satisfied (wrong filesystem?)
 ```
 
-This issue appeared when using the XFS filesystem for my /home/ directory. By default containers are configured to use the same file system as your root partition. To ensure general compatibility set the container driver to `overlay`. 
+This issue appeared when using the XFS filesystem for my /home/ directory. By default containers are configured to use the same file system as the root partition. To ensure general compatibility set the container driver to `overlay`. 
 
  As root modify `/etc/containers/storage.conf`: 
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -41,7 +41,7 @@ driver = "overlay"
 
 Next resolve the issue by wiping the entire `/var/lib/containers` directory.
 
-CAUTION!: This will delete all volumes in the directory! Do not do this without backing up the directory or copying your containers elsewhere!
+**CAUTION! This will delete all volumes in the directory! Do not do this without backing up the directory, copying your containers elsewhere, or making sure you don't need anything that exists there!**
 
 ```
 # WARNING: This will delete all container volumes, unless stored elsewhere!!

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -28,7 +28,7 @@ If you see the following error:
 Error: ".local/share/containers/storage/btrfs" is not on a btrfs filesystem: prerequisites for driver not satisfied (wrong filesystem?)
 ```
 
-This issue appeared when using the XFS filesystem for my /home/ directory. By default containers are configured to use a supported driver for the file system in use. To ensure general compatibility set the container driver to `overlay`. For more information see: `man 5 containers-storage.conf`.
+This issue appeared when using the XFS filesystem for my `/home` directory. By default rootless containers are configured to use a supported driver for the root file system. To ensure general compatibility set the container driver to `overlay`. For more information see: `man 5 containers-storage.conf`.
 
  As root modify `/etc/containers/storage.conf`: 
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -41,19 +41,14 @@ driver = "overlay"
 
 Next resolve the issue by wiping the entire `/var/lib/containers` directory.
 
-**CAUTION! This will delete all volumes in the directory! Do not do this without backing up the directory, copying your containers elsewhere, or making sure you don't need anything that exists there!**
+**CAUTION! This will delete all volumes in the directory! Do not do this without backing up the directory, copying your containers elsewhere, or making sure you don't need anything that exists there!** Stop all running containers: `podman-stop --all`
 
 ```
 # NOTE: If you have no running containers the first command to unmount is not required.
+# If you do have running containers stop them.
 
-umount /var/lib/containers/storage/btrfs  
+umount /var/lib/containers/storage/btrfs
 rm -rf /var/lib/containers
-```
-
-Now restart podman services:
-
-```
-sudo systemctl restart podman
 ```
 
 You should now be able to build documentation correctly using podman.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -45,9 +45,6 @@ Next resolve the issue by wiping the entire `/var/lib/containers` directory.
 **CAUTION! This will delete all volumes in the directory! Do not do this without backing up the directory, copying your containers elsewhere, or making sure you don't need anything that exists there! Before executing this action stop all running containers with: `podman-stop --all`**
 
 ```
-# NOTE: If you have no running containers the first command to unmount is not required.
-
-umount /var/lib/containers/storage/btrfs
 rm -rf /var/lib/containers
 ```
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -36,10 +36,7 @@ This issue appeared when using the XFS filesystem for my `/home` directory. By d
 [storage]
 
 # Default Storage Driver, Must be set for proper operation.
-#Switched to overlayfs due to https://github.com/containers/podman/issues/16882
-
-#driver = "btrfs"   <---- comment out btrfs
-driver = "overlay" <---- replace with overlay (generic)
+driver = "overlay"
 ```
 
 Next resolve the issue by wiping the entire `/var/lib/containers` directory.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -19,3 +19,45 @@ Assuming there are no ranges assigned (check `/etc/subuid` and `/etc/subguid`), 
 ```
 sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 MYUSER
 ```
+
+## Wrong filesystem error
+
+If you see the following error:
+
+```
+Error: ".local/share/containers/storage/btrfs" is not on a btrfs filesystem: prerequisites for driver not satisfied (wrong filesystem?)
+```
+
+For this issue I was using the XFS filesystem for my /home/ directory. By default containers are configured to use your root file system. 
+
+As root modify your `/etc/containers/storage.conf`: 
+
+```
+[storage]
+
+# Default Storage Driver, Must be set for proper operation.
+#Switched to overlayfs due to https://github.com/containers/podman/issues/16882
+
+#driver = "btrfs"   <---- comment out btrfs
+driver = "overlay" <---- replace with overlay (generic)
+```
+
+Next resolve the issue by nuking the entire `/var/lib/containers` directory.
+
+CAUTION!: This will delete all volumes in the directory! Do not do this without backing up the directory or copying your containers elsewhere!
+
+```
+# WARNING: This will delete all container volumes, unless stored elsewhere!!
+# NOTE: If you have no running containers the first command to unmount is not required.
+
+umount /var/lib/containers/storage/btrfs  
+rm -rf /var/lib/containers
+```
+
+Now restart podman services:
+
+```
+sudo systemctl restart podman
+```
+
+You should now be able to build documentation correctly using podman.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -44,7 +44,6 @@ Next resolve the issue by wiping the entire `/var/lib/containers` directory.
 **CAUTION! This will delete all volumes in the directory! Do not do this without backing up the directory, copying your containers elsewhere, or making sure you don't need anything that exists there!**
 
 ```
-# WARNING: This will delete all container volumes, unless stored elsewhere!!
 # NOTE: If you have no running containers the first command to unmount is not required.
 
 umount /var/lib/containers/storage/btrfs  

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -36,16 +36,16 @@ This issue appeared when using the XFS filesystem for my `/home` directory. By d
 [storage]
 
 # Default Storage Driver, Must be set for proper operation.
+#driver = "btrfs"
 driver = "overlay"
 ```
 
 Next resolve the issue by wiping the entire `/var/lib/containers` directory.
 
-**CAUTION! This will delete all volumes in the directory! Do not do this without backing up the directory, copying your containers elsewhere, or making sure you don't need anything that exists there!** Stop all running containers: `podman-stop --all`
+**CAUTION! This will delete all volumes in the directory! Do not do this without backing up the directory, copying your containers elsewhere, or making sure you don't need anything that exists there!** Before executing this action stop all running containers with: podman-stop --all
 
 ```
 # NOTE: If you have no running containers the first command to unmount is not required.
-# If you do have running containers stop them.
 
 umount /var/lib/containers/storage/btrfs
 rm -rf /var/lib/containers

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -28,7 +28,7 @@ If you see the following error:
 Error: ".local/share/containers/storage/btrfs" is not on a btrfs filesystem: prerequisites for driver not satisfied (wrong filesystem?)
 ```
 
-This issue appeared when using the XFS filesystem for my /home/ directory. By default containers are configured to use a supported driver for the file system in use. To ensure general compatibility set the container driver to `overlay`. 
+This issue appeared when using the XFS filesystem for my /home/ directory. By default containers are configured to use a supported driver for the file system in use. To ensure general compatibility set the container driver to `overlay`. For more information see: `man 5 containers-storage.conf`.
 
  As root modify `/etc/containers/storage.conf`: 
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -42,7 +42,7 @@ driver = "overlay"
 
 Next resolve the issue by wiping the entire `/var/lib/containers` directory.
 
-**CAUTION! This will delete all volumes in the directory! Do not do this without backing up the directory, copying your containers elsewhere, or making sure you don't need anything that exists there!** Before executing this action stop all running containers with: podman-stop --all
+**CAUTION! This will delete all volumes in the directory! Do not do this without backing up the directory, copying your containers elsewhere, or making sure you don't need anything that exists there! Before executing this action stop all running containers with: `podman-stop --all`**
 
 ```
 # NOTE: If you have no running containers the first command to unmount is not required.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -28,9 +28,9 @@ If you see the following error:
 Error: ".local/share/containers/storage/btrfs" is not on a btrfs filesystem: prerequisites for driver not satisfied (wrong filesystem?)
 ```
 
-For this issue I was using the XFS filesystem for my /home/ directory. By default containers are configured to use your root file system. 
+This issue appeared when using the XFS filesystem for my /home/ directory. By default containers are configured to use the same file system as your root partition. To ensure general compatibility set the container driver to `overlay`. 
 
-As root modify your `/etc/containers/storage.conf`: 
+ As root modify `/etc/containers/storage.conf`: 
 
 ```
 [storage]
@@ -42,7 +42,7 @@ As root modify your `/etc/containers/storage.conf`:
 driver = "overlay" <---- replace with overlay (generic)
 ```
 
-Next resolve the issue by nuking the entire `/var/lib/containers` directory.
+Next resolve the issue by wiping the entire `/var/lib/containers` directory.
 
 CAUTION!: This will delete all volumes in the directory! Do not do this without backing up the directory or copying your containers elsewhere!
 


### PR DESCRIPTION
Provides a solution for the message:

```
Error: ".local/share/containers/storage/btrfs" is not on a btrfs filesystem: prerequisites for driver not satisfied (wrong filesystem?)
```