### PR TITLE
Improve error handling

### DIFF
--- a/uyuni-docs-helper
+++ b/uyuni-docs-helper
@@ -163,6 +163,9 @@ else
   if [ ! -d ${LOCALCLONE} ]; then
     print_error "${LOCALCLONE} is not a directory or does not exist"
     exit 2
+  elif [ ! -d ${LOCALCLONE}/.git ]; then
+    print_error "${LOCALCLONE} is not a Git repository"
+    exit 2
   else
     SOURCE="-v ${LOCALCLONE}:/tmp/uyuni-docs --userns=keep-id"
     if [ "${COMMAND}" != "help" ]; then
@@ -179,7 +182,7 @@ fi
 
 if [ -z ${LOCALCLONE} ]; then
   SOURCE="${SOURCE} -e GITREPO=${GITREPO} -e GITREF=${GITREF}"
-  fi
+fi
 
 print_info "Pulling the latest container image..."
 podman pull ${IMAGE}
@@ -194,11 +197,14 @@ fi
 podman run -ti --rm ${SOURCE} -e PRODUCT=${PRODUCT} -e COMMAND=${COMMAND} -e SERVE=${SERVE} ${PORTS} ${IMAGE}
 RET=${?}
 
-if [ ! -z ${OUTDIR} ] && [ "${COMMAND}" != "help" ]; then
-    print_info "You can find find the build output at ${OUTDIR}"
+if [ ${RET} -eq 0 ]; then
+    if [ ! -z ${OUTDIR} ] && [ "${COMMAND}" != "help" ]; then
+        print_info "You can find find the build output at ${OUTDIR}"
+    fi
+else
+   print_error "There were errors! Please review the log!"
+   print_error "Depending on the error, there could also be build outputs at ${OUTDIR}"
 fi
 
-if [ ${RET} -ne 0 ]; then
-   print_error "There were errors! Please review the log!"
+
    exit ${RET}
-fi


### PR DESCRIPTION
Check if `-l` is a Git repository
```
$ ./uyuni-docs-helper -l /tmp -c blah -p suma
[ERROR] /tmp is not a Git repository
```

If there are errors, show the output folder as part of an error, and specify that it could have or could not have stuff.
```
$ ./uyuni-docs-helper -l ../uyuni-docs -c blah -p suma
[INFO] Output will be stored at ../uyuni-docs/build
[INFO] Pulling the latest container image...
Trying to pull docker.io/juliogonzalez/uyuni-docs:latest...
[....]
789f2706ec7a85c12b43e9a27d67afef60e6c7744328ad5e363453c91fd5782a
[INFO] Bulding the doc...
WARN[0000] Path "/etc/SUSEConnect" from "/etc/containers/mounts.conf" doesn't exist, skipping 
WARN[0000] Path "/etc/zypp/credentials.d/SCCcredentials" from "/etc/containers/mounts.conf" doesn't exist, skipping 
====================================================================
 Git repository: A folder from outside the container is being used
 Product: suma
 Make command: blah
====================================================================
./configure suma
Config file loaded successfully
Creating Makefile for each language..
Makefiles successfully created
Including new Makefiles in Makefile.lang
Creating new target using books target..
Creating new target using language target..
Creating entities.adoc
Creating parameters specific for suma for entities file..
Creating site.yml.
Creating parameters specific for suma in site.yml
Creating parameters specific for suma in antora.yml
Configuration Completed!
make: *** No rule to make target 'blah'.  Stop.
[ERROR] There were errors! Please review the log!
[ERROR] Depending on the error, there could also be build outputs at ../uyuni-docs/build
```

Fixes #17 