### PR TITLE
Add support for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ or
 
 - Have `docker` installed and an alias `podman` that calls `docker` (for bash that means adding `alias docker='podman'` to the file `~/.alias`)
 
+## macOS users
+
+Install the package `gnu-getopt` via e.g. Homebrew (https://brew.sh):
+
+```bash
+brew install gnu-getopt
+```
+
+Get Podman ready
+
+```bash
+podman machine init
+podman machine start
+# verify the connection
+podman system connection list
+```
 
 ## For image maintainers
 

--- a/uyuni-docs-helper
+++ b/uyuni-docs-helper
@@ -36,10 +36,14 @@ GITREF='master'
 
 # use gnu-getopt on macOS
 getopt_for_macos() {
-  if [ $(uname -s) == 'Darwin' ]; then
+  if [ "$(uname -s)" == 'Darwin' ]; then
     if [ ! -f /usr/local/opt/gnu-getopt/bin/getopt ]; then
-      print_error
-      echo "Please install gnu-getopt via Homebrew with: brew install gnu-getopt"
+        if [ "${SHELL}" == "/usr/local/bin/fish" ]; then
+          print_error "The fish shell is not supported (yet), please use bash or zsh for now"
+          exit 1
+        fi
+      print_error "Please install gnu-getopt via Homebrew with: brew install gnu-getopt"
+      exit 1
     else
       export PATH="$(brew --prefix gnu-getopt)/bin:$PATH"
     fi

--- a/uyuni-docs-helper
+++ b/uyuni-docs-helper
@@ -34,6 +34,18 @@ GITREPO='https://github.com/uyuni-project/uyuni-docs.git'
 # Default Git reference
 GITREF='master'
 
+# use gnu-getopt on macOS
+getopt_for_macos() {
+  if [ $(uname -s) == 'Darwin' ]; then
+    if [ ! -f /usr/local/opt/gnu-getopt/bin/getopt ]; then
+      print_error
+      echo "Please install gnu-getopt via Homebrew with: brew install gnu-getopt"
+    else
+      export PATH="$(brew --prefix gnu-getopt)/bin:$PATH"
+    fi
+  fi
+}
+
 print_info() {
   echo -e "\033[1;36m[INFO] ${1}\033[0m"
 }
@@ -95,6 +107,9 @@ print_help() {
   echo "-s|--serve               Start a HTTP server at the end of the build so the"
   echo "                         documentation can be inspected (disabled by default)"
 }
+
+# adjustments for macOS
+getopt_for_macos
 
 # read the options
 ARGS=$(getopt -o hg:r:l:o:p:c:t:s --long help,gitrepo:,gitref:,localclone:,output:,product:,command:,tag:,serve -n "${SCRIPT}" -- "$@")


### PR DESCRIPTION
This adds support for macOS by using `gnu-getopt`. Tested on macOS 14.1 (Sonoma). This requires the package `gnu-getopt` that can be installed via Homebrew with `brew install gnu-getopt`.

Fixes https://github.com/uyuni-project/uyuni-docs-helper/issues/8

When using this works. Since the default shell on macOS is zsh, this is fine for now. With the fish shell, there are still problems with regard to `getopt`.
```bash
❯ zsh
dom@mbook-dom uyuni-docs-helper % ./uyuni-docs-helper
[ERROR] Incorrect syntax: -c is mandatory (use uyuni-docs-helper -h for help)

dom@mbook-dom uyuni-docs-helper % ./uyuni-docs-helper -h

Build the Uyuni doc using a container and (optionally) serve it for verification via HTTP

Syntax:

uyuni-docs-helper <ARGUMENTS>

Mandatory arguments:

-p|--product <uyuni|suma>   Build the documentation for either Uyuni or SUSE Manager
-c|--command <make command> Use the desired command to build html/pdf, html&pdf, etc...
                            for example: 'all-uyuni'. You can use 'help' to list all
                            possible commands. Be aware you still need to specify
                            one source for this to work

uyuni-docs-helper can build documentation from two sources. Different parameters apply for each case.
If both a local git repository and a remote git repository are specified, the local git
repository is used

Remote Git repository:
-g|--gitrepo <REPOSITORY> A path to a HTTP git repository where the code for the
                          documentation is.
                          If the value does not start with 'https://'
                          then the value is considered as a GitHUb user/organization and
                          the URL in the form https://github.com/<REPOSITORY>/uyuni-docs.git
                          will be used
                          If not specified at all, the default value will be
                          https://github.com/uyuni-project/uyuni-docs.git
-r|--gitref <REFERENCE>   A git branch (master by default)
-o|--output <PATH>        An existing path to store the output of the build. A directory
                          'build' will be created inside. Optional

Local Git repository:
-l|--localclone <GIT_CLONE> A path to a local git repository. The output of the build will
                            be placed inside this path as a 'build' directory

Optional arguments:
-t|--tag                 Use a secific tag for the container image. Can be useful if you
                         want to build an old documentation using an old version of the
                         toolchain. (latest used by default)
-s|--serve               Start a HTTP server at the end of the build so the
                         documentation can be inspected (disabled by default)

dom@mbook-dom uyuni-docs-helper % ./uyuni-docs-helper --help

Build the Uyuni doc using a container and (optionally) serve it for verification via HTTP

Syntax:

uyuni-docs-helper <ARGUMENTS>

Mandatory arguments:

-p|--product <uyuni|suma>   Build the documentation for either Uyuni or SUSE Manager
-c|--command <make command> Use the desired command to build html/pdf, html&pdf, etc...
                            for example: 'all-uyuni'. You can use 'help' to list all
                            possible commands. Be aware you still need to specify
                            one source for this to work

uyuni-docs-helper can build documentation from two sources. Different parameters apply for each case.
If both a local git repository and a remote git repository are specified, the local git
repository is used

Remote Git repository:
-g|--gitrepo <REPOSITORY> A path to a HTTP git repository where the code for the
                          documentation is.
                          If the value does not start with 'https://'
                          then the value is considered as a GitHUb user/organization and
                          the URL in the form https://github.com/<REPOSITORY>/uyuni-docs.git
                          will be used
                          If not specified at all, the default value will be
                          https://github.com/uyuni-project/uyuni-docs.git
-r|--gitref <REFERENCE>   A git branch (master by default)
-o|--output <PATH>        An existing path to store the output of the build. A directory
                          'build' will be created inside. Optional

Local Git repository:
-l|--localclone <GIT_CLONE> A path to a local git repository. The output of the build will
                            be placed inside this path as a 'build' directory

Optional arguments:
-t|--tag                 Use a secific tag for the container image. Can be useful if you
                         want to build an old documentation using an old version of the
                         toolchain. (latest used by default)
-s|--serve               Start a HTTP server at the end of the build so the
                         documentation can be inspected (disabled by default)
dom@mbook-dom uyuni-docs-helper %
```