### PR TITLE
Update the base image to openSUSE Leap 15.5

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.4
+FROM opensuse/leap:15.5
 MAINTAINER Julio Gonzalez Gil <jgonzalez@suse.com>
 
 ARG REGULARUSER=docs


### PR DESCRIPTION
openSUSE Leap 15.4 is now EoL, so I am updating the base image to openSUSE Leap 15.5

I tried to build the SUSE Manager master documentation with an updated image I built locally, and it worked fine.