### PR TITLE
CI: Add Dependabot GitHub workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## What does this PR change?

This will add checks from Dependabot to keep the [GitHub Actions](https://github.com/uyuni-project/uyuni-docs-helper/blob/main/.github/workflows/build-and-publish-container-images.yml) up to date.

For example, Node 16 will be deprecated soon:
![image](https://github.com/uyuni-project/uyuni-docs-helper/assets/12104291/f0f2d7db-51b5-4a24-9632-0087d43d8e47)



## Links

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions
- https://github.com/uyuni-project/uyuni/blob/master/.github/dependabot.yml
- https://github.com/uyuni-project/sumaform/blob/master/.github/dependabot.yml
- https://github.com/SUSE/susemanager-ci/blob/master/.github/dependabot.yml
