### PR TITLE
Always calculate the absolute path for the output directory

### DIFF
--- a/uyuni-docs-helper
+++ b/uyuni-docs-helper
@@ -66,6 +66,13 @@ print_incorrect_syntax() {
   exit 1
 }
 
+get_dir_abs_path() {
+  (
+    cd "$(dirname ${1})"
+    echo "${PWD}/$(basename $1)"
+  )
+}
+
 print_help() {
   echo ""
   echo "Build the Uyuni doc using a container and (optionally) serve it for verification via HTTP"
@@ -181,6 +188,7 @@ if [ -z ${LOCALCLONE} ]; then
       print_error "${OUTPUT} is not a directory or does not exist"
       exit 2
     else
+      OUTPUT="$(get_dir_abs_path ${OUTPUT})"
       SOURCE="${SOURCE} -v ${OUTPUT}:/tmp/output${SELINUXMOUNT} --userns=keep-id"
       if [ "${COMMAND}" != "help" ]; then
         print_info "Output will be stored at ${OUTPUT}/build"


### PR DESCRIPTION
Preparing the documentation on Friday, I noticed that if I used `-o package`, the build worked, but the `package` directory didn't contain anything.

Seems this is fixed by always specifying absolute paths when preparing the bind mount for podman, so this PR is precisely calculating that absolute path.

```
build/en/pdf/uyuni_quickstart_guide.pdf
build/en/pdf/uyuni_client-configuration_guide.pdf
build/en/pdf/uyuni_installation-and-upgrade_guide.pdf
build/en/pdf/uyuni_administration_guide.pdf
build/en/pdf/uyuni_retail_guide.pdf
mkdir -p build/packages
mv uyuni-docs_en.tar.gz uyuni-docs_en-pdf.tar.gz build/packages
[INFO] You can find find the build output at /home/juliogonzalez/Documents/development/git/suse/uyuni-docs-helper/package/build

real    3m49,440s
user    0m0,513s
sys     0m0,279s

$ ls -l /home/juliogonzalez/Documents/development/git/suse/uyuni-docs-helper/package/build
total 8
drwxr-xr-x 5 juliogonzalez users 4096 ago 26 09:49 en
drwxr-xr-x 2 juliogonzalez users 4096 ago 26 09:49 packages
```