### PR TITLE
Update tools to match new branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This a result of [SUSE's Hack Week 22](https://hackweek.opensuse.org/22/projects
 
 ### Example
 
-`./uyuni-docs-helper -r master -o /tmp/test -c obs-packages-suma-en -p suma` would build the HTML and PDFs for English language, from the `master` branch at https://github.com/uyuni-project/uyuni-docs (default repository), for SUSE Manager.
+`./uyuni-docs-helper -r master -o /tmp/test -c obs-packages-mlm-en -p mlm` would build the HTML and PDFs for English language, from the `master` branch at https://github.com/uyuni-project/uyuni-docs (default repository), for SUSE Multi-Linux Manager.
 
 ## For image maintainers
 

--- a/uyuni-docs-helper
+++ b/uyuni-docs-helper
@@ -83,7 +83,7 @@ print_help() {
   echo ""
   echo "Mandatory arguments:"
   echo ""
-  echo "-p|--product <uyuni|suma>   Build the documentation for either Uyuni or SUSE Manager"
+  echo "-p|--product <uyuni|mlm>   Build the documentation for either Uyuni or SUSE Multi-Linux Manager"
   echo "-c|--command <make command> Use the desired command to build html/pdf, html&pdf, etc..."
   echo "                            for example: 'all-uyuni'. You can use 'help' to list all"
   echo "                            possible commands. Be aware you still need to specify"
@@ -163,7 +163,7 @@ if [ "${COMMAND}" == "help" ]; then
     print_incorrect_syntax "A source (a remote or local git repository) is needed for this."
   # Define a default product, if none is available, so we can show the help
   elif [ -z ${PRODUCT} ]; then
-    PRODUCT='suma'
+    PRODUCT='mlm'
   fi
 fi
 


### PR DESCRIPTION
Updates the following:

- [x] Readme (Mentions of SUSE Manager have been adjusted to SUSE Multi-Linux Manager)
- [x] uyuni-docs-helper script (`suma -> mlm`)