### PR TITLE
CI: Build container also for arm64

### DIFF
--- a/.github/workflows/build-and-publish-container-images.yml
+++ b/.github/workflows/build-and-publish-container-images.yml
@@ -6,6 +6,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build-and-push-image:
@@ -16,17 +17,26 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
+      - name: Set up QEMU for multi-arch build
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+
+      - name: Set up Docker Buildx or multi-platform builds
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for the container image
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 #v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
       - name: Build and push container image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 #v6.19.2
         with:
@@ -34,3 +44,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ env.PLATFORMS }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This a result of [SUSE's Hack Week 22](https://hackweek.opensuse.org/22/projects
 
 - `image` directory: Contains the Dockerfile, the `startup.sh` script for the container, and the `build-locally` helper (that can be used to build the container locally for testing, passing arguments to the build, such as `--no-cache` is allowed). See below for more details
 - `.github/workflows`: Contains the `build-and-publish-container-images.yml` workflow definition to build and publish the image to the GitHub Container registry after each change on the repository
+- build targets are `x86_64` (`amd64`) and `arm64`
 
 # Requirements
 


### PR DESCRIPTION
This adds the possibility to build the container not only for amd64, but also for arm64, similar to what we use in the [Uyuni PR tests](https://github.com/uyuni-project/uyuni/blob/33734d711404df78a2462a80081873bd2b6a4e87/.github/workflows/build_containers.yml#L20).

Building for both architectures works. I was able to pull the new `arm64` image on my ARM mac. I copied the workflow over from what @srbarrios did in https://github.com/uyuni-project/uyuni/pull/11102.

The build was successful in my fork, see https://github.com/nodeg/uyuni-docs-helper/actions/runs/22067361159/job/63762605648
<img width="1608" height="1171" alt="image" src="https://github.com/user-attachments/assets/22a65c97-6f7e-448b-a537-d62b7f2989e8" />
