### PR TITLE
fix: harden supply chain security

### DIFF
--- a/.github/workflows/build-and-publish-container-images.yml
+++ b/.github/workflows/build-and-publish-container-images.yml
@@ -1,5 +1,9 @@
 name: Create and publish the Docker image
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
 
@@ -11,18 +15,15 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Set up QEMU for multi-arch build
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a #v4.0.1
 
       - name: Set up Docker Buildx or multi-platform builds
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
 
       - name: Log in to the Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:16.0
+FROM opensuse/leap:16.0@sha256:859560554b625c225fa767b76d61253d529b95d082c2d68579ad69168d5e3da7
 LABEL org.opencontainers.image.authors="jgonzalez@suse.com"
 
 ARG REGULARUSER=docs
@@ -44,14 +44,20 @@ USER ${REGULARUSER}
 
 # NVM and Node
 # see https://docs.antora.org/antora/latest/install/linux-requirements/
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash && \
+# renovate: datasource=github-releases depName=nvm-sh/nvm
+ARG NVM_VERSION=v0.40.3
+ARG NVM_INSTALL_SHA256=2d8359a64a3cb07c02389ad88ceecd43f2fa469c06104f92f98df5b6f315275f
+RUN curl -sL -o /tmp/nvm-install.sh "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh" && \
+    echo "${NVM_INSTALL_SHA256}  /tmp/nvm-install.sh" | sha256sum -c - && \
+    bash /tmp/nvm-install.sh && \
+    rm -f /tmp/nvm-install.sh && \
     source ~/.bashrc && \
     nvm install --lts && \
     nvm use --lts
 
 # Antora 3.1, Asciidoctor and Lunr.js extension
 RUN source ~/.bashrc && \
-    npm install -g npm@latest \
+    npm install -g npm@11.4.1 \
     @antora/cli@3.1 \
     @antora/site-generator@3.1 \
     @antora/lunr-extension \


### PR DESCRIPTION
## Summary

This PR addresses supply chain security issues identified in the security guidelines.

### Changes

- **Pin base image to digest** (§3.7): `opensuse/leap:16.0` pinned to `@sha256:859560...` to prevent tag mutation attacks
- **Eliminate `curl | bash`** (§3.4): NVM install script is now downloaded, checksum-verified (sha256), then executed
- **Pin `npm` to specific version** (§3.2): Replaced `npm@latest` with `npm@11.4.1`
- **Add version comments to GHA actions** (§3.8.2): Added version annotations to `setup-qemu-action` and `setup-buildx-action`
- **Set top-level workflow permissions** (§3.8.1): Moved permissions to workflow level with minimal scopes (`contents: read`, `packages: write`)

### References

- https://github.com/SUSE/spacewalk/issues/30199